### PR TITLE
Added the dependency to angular so that sequencing is done correctly …

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,5 +17,8 @@
   "ignore": [
     "**/.*",
     "node_modules"
-  ]
+  ],
+  "dependencies": {
+      "angular": ">=1.5.5"
+  }
 }


### PR DESCRIPTION
…on gulp builds.

Otherwise this can be loaded before angular then wont be able to find the angular reference.